### PR TITLE
Fix inconcistency with <leader>ff in dashboard

### DIFF
--- a/lua/cosmic/plugins/dashboard/init.lua
+++ b/lua/cosmic/plugins/dashboard/init.lua
@@ -26,7 +26,7 @@ g.dashboard_session_directory = vim.fn.stdpath('data') .. '/sessions'
 g.dashboard_custom_section = {
   find_file = {
     description = { icons.file1 .. ' Find File           <leader>ff' },
-    command = 'Telescope find_files',
+    command = 'lua require("cosmic.plugins.telescope.mappings").project_files()',
   },
   file_explorer = {
     description = { icons.file2 .. ' File Manager        <C-n>     ' },


### PR DESCRIPTION
Dashboard's `<leader>ff` now uses the same command defined in [telescope/mappings.lua](https://github.com/CosmicNvim/CosmicNvim/blob/0aef3f630bf7f07516b3b6be421899f9b4c8cbbf/lua/cosmic/plugins/telescope/mappings.lua#L14)